### PR TITLE
Edge corruption fix

### DIFF
--- a/WinQuake/r_bsp.c
+++ b/WinQuake/r_bsp.c
@@ -188,9 +188,9 @@ void R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 		lastdist = DotProduct (plastvert->position, tplane.normal) -
 				   tplane.dist;
 
-// CyanBun96: the >= instead of > in lastside and side prevents corruption in
-// some edge cases (no pun intended)
-		if (lastdist >= 0)
+// CyanBun96: comparison of lastdist and dist against a low threshold instead of
+// 0 prevents corruption in some edge cases (no pun intended)
+		if (lastdist >= 0.001)
 			lastside = 0;
 		else
 			lastside = 1;
@@ -199,7 +199,7 @@ void R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 
 		dist = DotProduct (pvert->position, tplane.normal) - tplane.dist;
 
-		if (dist >= 0)
+		if (dist >= 0.001)
 			side = 0;
 		else
 			side = 1;

--- a/WinQuake/r_bsp.c
+++ b/WinQuake/r_bsp.c
@@ -188,7 +188,9 @@ void R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 		lastdist = DotProduct (plastvert->position, tplane.normal) -
 				   tplane.dist;
 
-		if (lastdist > 0)
+// CyanBun96: the >= instead of > in lastside and side prevents corruption in
+// some edge cases (no pun intended)
+		if (lastdist >= 0)
 			lastside = 0;
 		else
 			lastside = 1;
@@ -197,7 +199,7 @@ void R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 
 		dist = DotProduct (pvert->position, tplane.normal) - tplane.dist;
 
-		if (dist > 0)
+		if (dist >= 0)
 			side = 0;
 		else
 			side = 1;


### PR DESCRIPTION
Fixes https://github.com/atsb/NakedWinQuake/issues/14

Second attempt, as the previous one caused a similar glitch in ad_magna (which NakedWinQuake can't even load but still).

This fix isn't theoretically perfect either, but it fixes both of the issues I found in qrustyquake (which behaves functionally the same as far as brush entity culling goes).

To properly match the original 1997 WINQUAKE.EXE's behavior you'd need to mess with floating point precision in ways that would probably be much less portable than what this fix does though, so I'm submitting for now.